### PR TITLE
Fix missing pthread dependency in wscript files

### DIFF
--- a/src/wscript
+++ b/src/wscript
@@ -24,6 +24,6 @@ def build(bld):
             source  = 'cui/' + program + '_main.cpp',
             target  = '../' + program,
             defines = ['NDEBUG'],
-            use     = ['algorithm', 'my_common', 'gflags'],
+            use     = ['algorithm', 'my_common', 'gflags', 'pthread'],
             includes = ['../lib/', '.']
         )

--- a/wscript
+++ b/wscript
@@ -13,6 +13,7 @@ def configure(conf):
     conf.load('compiler_cxx')
     conf.check_tool('compiler_cxx')
     conf.env.append_value('CXXFLAGS', ['-Wall', '-Wextra', '-g', '-O3', '-std=c++11'])
+    conf.check_cxx(lib = ['pthread'], uselib_store = 'pthread')
     
 def build(bld):
     bld.recurse('lib')


### PR DESCRIPTION
Compilation with waf fails with undefined references to pthread library.

```
[16/23] cxxprogram: bin/src/test/two_layer_queue_test_main.cpp.3.o -> bin/src/test/two_layer_queue_test
lib/libgtest.a(gtest-all.cpp.1.o): In function `testing::internal::ThreadLocal<testing::TestPartResultReporterInterface*>::~ThreadLocal()':
/home/andrei/Downloads/dynamic-distance-query/lib/gtest/gtest.h:2398: undefined reference to `pthread_getspecific'
/home/andrei/Downloads/dynamic-distance-query/lib/gtest/gtest.h:2402: undefined reference to `pthread_key_delete'
lib/libgtest.a(gtest-all.cpp.1.o): In function `testing::internal::ThreadLocal<testing::TestPartResultReporterInterface*>::~ThreadLocal()':
/home/andrei/Downloads/dynamic-distance-query/lib/gtest/gtest.h:2398: undefined reference to `pthread_getspecific'
/home/andrei/Downloads/dynamic-distance-query/lib/gtest/gtest.h:2402: undefined reference to `pthread_key_delete'
lib/libgtest.a(gtest-all.cpp.1.o): In function `testing::internal::ThreadLocal<std::vector<testing::internal::TraceInfo, std::allocator<testing::internal::TraceInfo> > >::~ThreadLocal()':
/home/andrei/Downloads/dynamic-distance-query/lib/gtest/gtest.h:2398: undefined reference to `pthread_getspecific'
/home/andrei/Downloads/dynamic-distance-query/lib/gtest/gtest.h:2402: undefined reference to `pthread_key_delete'
lib/libgtest.a(gtest-all.cpp.1.o): In function `testing::internal::ThreadLocal<std::vector<testing::internal::TraceInfo, std::allocator<testing::internal::TraceInfo> > >::CreateKey()':
/home/andrei/Downloads/dynamic-distance-query/lib/gtest/gtest.h:2427: undefined reference to `pthread_key_create'
lib/libgtest.a(gtest-all.cpp.1.o): In function `testing::internal::ThreadLocal<std::vector<testing::internal::TraceInfo, std::allocator<testing::internal::TraceInfo> > >::GetOrCreateValue() const':
/home/andrei/Downloads/dynamic-distance-query/lib/gtest/gtest.h:2434: undefined reference to `pthread_getspecific'
/home/andrei/Downloads/dynamic-distance-query/lib/gtest/gtest.h:2441: undefined reference to `pthread_setspecific'
lib/libgtest.a(gtest-all.cpp.1.o): In function `testing::internal::ThreadLocal<testing::TestPartResultReporterInterface*>::GetOrCreateValue() const':
/home/andrei/Downloads/dynamic-distance-query/lib/gtest/gtest.h:2434: undefined reference to `pthread_getspecific'
/home/andrei/Downloads/dynamic-distance-query/lib/gtest/gtest.h:2441: undefined reference to `pthread_setspecific'
lib/libgflags.a(gflags.cc.2.o): In function `gflags_mutex_namespace::Mutex::Lock()':
/home/andrei/Downloads/dynamic-distance-query/bin/../lib/gflags/mutex.h:265: undefined reference to `pthread_rwlock_wrlock'
lib/libgflags.a(gflags.cc.2.o): In function `gflags_mutex_namespace::Mutex::Unlock()':
/home/andrei/Downloads/dynamic-distance-query/bin/../lib/gflags/mutex.h:266: undefined reference to `pthread_rwlock_unlock'
lib/libgflags.a(gflags.cc.2.o): In function `gflags_mutex_namespace::Mutex::Mutex()':
/home/andrei/Downloads/dynamic-distance-query/bin/../lib/gflags/mutex.h:258: undefined reference to `pthread_rwlock_init'
lib/libgflags.a(gflags.cc.2.o): In function `gflags_mutex_namespace::Mutex::Lock()':
/home/andrei/Downloads/dynamic-distance-query/bin/../lib/gflags/mutex.h:265: undefined reference to `pthread_rwlock_wrlock'
lib/libgflags.a(gflags.cc.2.o): In function `gflags_mutex_namespace::Mutex::Unlock()':
/home/andrei/Downloads/dynamic-distance-query/bin/../lib/gflags/mutex.h:266: undefined reference to `pthread_rwlock_unlock'
lib/libgflags.a(gflags.cc.2.o): In function `gflags_mutex_namespace::Mutex::Lock()':
/home/andrei/Downloads/dynamic-distance-query/bin/../lib/gflags/mutex.h:265: undefined reference to `pthread_rwlock_wrlock'
lib/libgflags.a(gflags.cc.2.o): In function `gflags_mutex_namespace::Mutex::Unlock()':
/home/andrei/Downloads/dynamic-distance-query/bin/../lib/gflags/mutex.h:266: undefined reference to `pthread_rwlock_unlock'
lib/libgflags.a(gflags.cc.2.o): In function `gflags_mutex_namespace::Mutex::Lock()':
/home/andrei/Downloads/dynamic-distance-query/bin/../lib/gflags/mutex.h:265: undefined reference to `pthread_rwlock_wrlock'
lib/libgflags.a(gflags.cc.2.o): In function `gflags_mutex_namespace::Mutex::Unlock()':
/home/andrei/Downloads/dynamic-distance-query/bin/../lib/gflags/mutex.h:266: undefined reference to `pthread_rwlock_unlock'
/home/andrei/Downloads/dynamic-distance-query/bin/../lib/gflags/mutex.h:266: undefined reference to `pthread_rwlock_unlock'
lib/libgflags.a(gflags.cc.2.o): In function `gflags_mutex_namespace::Mutex::Lock()':
/home/andrei/Downloads/dynamic-distance-query/bin/../lib/gflags/mutex.h:265: undefined reference to `pthread_rwlock_wrlock'
lib/libgflags.a(gflags.cc.2.o): In function `gflags_mutex_namespace::Mutex::Unlock()':
/home/andrei/Downloads/dynamic-distance-query/bin/../lib/gflags/mutex.h:266: undefined reference to `pthread_rwlock_unlock'
lib/libgflags.a(gflags.cc.2.o): In function `gflags_mutex_namespace::Mutex::Lock()':
/home/andrei/Downloads/dynamic-distance-query/bin/../lib/gflags/mutex.h:265: undefined reference to `pthread_rwlock_wrlock'
lib/libgflags.a(gflags.cc.2.o): In function `gflags_mutex_namespace::Mutex::Unlock()':
/home/andrei/Downloads/dynamic-distance-query/bin/../lib/gflags/mutex.h:266: undefined reference to `pthread_rwlock_unlock'
lib/libgflags.a(gflags.cc.2.o): In function `google::RegisterFlagValidator(bool const*, bool (*)(char const*, bool))':
/home/andrei/Downloads/dynamic-distance-query/bin/../lib/gflags/gflags.cc:1823: undefined reference to `pthread_rwlock_unlock'
/home/andrei/Downloads/dynamic-distance-query/bin/../lib/gflags/gflags.cc:1823: undefined reference to `pthread_rwlock_wrlock'
lib/libgflags.a(gflags.cc.2.o): In function `google::RegisterFlagValidator(int const*, bool (*)(char const*, int))':
/home/andrei/Downloads/dynamic-distance-query/bin/../lib/gflags/gflags.cc:1823: undefined reference to `pthread_rwlock_unlock'
/home/andrei/Downloads/dynamic-distance-query/bin/../lib/gflags/gflags.cc:1823: undefined reference to `pthread_rwlock_wrlock'
lib/libgflags.a(gflags.cc.2.o): In function `google::RegisterFlagValidator(long const*, bool (*)(char const*, long))':
/home/andrei/Downloads/dynamic-distance-query/bin/../lib/gflags/gflags.cc:1823: undefined reference to `pthread_rwlock_unlock'
/home/andrei/Downloads/dynamic-distance-query/bin/../lib/gflags/gflags.cc:1823: undefined reference to `pthread_rwlock_wrlock'
lib/libgflags.a(gflags.cc.2.o): In function `google::RegisterFlagValidator(unsigned long const*, bool (*)(char const*, unsigned long))':
/home/andrei/Downloads/dynamic-distance-query/bin/../lib/gflags/gflags.cc:1823: undefined reference to `pthread_rwlock_unlock'
/home/andrei/Downloads/dynamic-distance-query/bin/../lib/gflags/gflags.cc:1823: undefined reference to `pthread_rwlock_wrlock'
lib/libgflags.a(gflags.cc.2.o): In function `google::RegisterFlagValidator(double const*, bool (*)(char const*, double))':
/home/andrei/Downloads/dynamic-distance-query/bin/../lib/gflags/gflags.cc:1823: undefined reference to `pthread_rwlock_unlock'
/home/andrei/Downloads/dynamic-distance-query/bin/../lib/gflags/gflags.cc:1823: undefined reference to `pthread_rwlock_wrlock'
lib/libgflags.a(gflags.cc.2.o): In function `gflags_mutex_namespace::Mutex::Unlock()':
/home/andrei/Downloads/dynamic-distance-query/bin/../lib/gflags/mutex.h:266: undefined reference to `pthread_rwlock_unlock'
lib/libgflags.a(gflags.cc.2.o): In function `gflags_mutex_namespace::Mutex::Lock()':
/home/andrei/Downloads/dynamic-distance-query/bin/../lib/gflags/mutex.h:265: undefined reference to `pthread_rwlock_wrlock'
lib/libgflags.a(gflags.cc.2.o): In function `gflags_mutex_namespace::Mutex::~Mutex()':
/home/andrei/Downloads/dynamic-distance-query/bin/../lib/gflags/mutex.h:264: undefined reference to `pthread_rwlock_destroy'
lib/libgflags.a(gflags.cc.2.o): In function `gflags_mutex_namespace::Mutex::Lock()':
/home/andrei/Downloads/dynamic-distance-query/bin/../lib/gflags/mutex.h:265: undefined reference to `pthread_rwlock_wrlock'
lib/libgflags.a(gflags.cc.2.o): In function `gflags_mutex_namespace::Mutex::Unlock()':
/home/andrei/Downloads/dynamic-distance-query/bin/../lib/gflags/mutex.h:266: undefined reference to `pthread_rwlock_unlock'
/home/andrei/Downloads/dynamic-distance-query/bin/../lib/gflags/mutex.h:266: undefined reference to `pthread_rwlock_unlock'
lib/libgflags.a(gflags.cc.2.o): In function `gflags_mutex_namespace::Mutex::Lock()':
/home/andrei/Downloads/dynamic-distance-query/bin/../lib/gflags/mutex.h:265: undefined reference to `pthread_rwlock_wrlock'
/home/andrei/Downloads/dynamic-distance-query/bin/../lib/gflags/mutex.h:265: undefined reference to `pthread_rwlock_wrlock'
lib/libgflags.a(gflags.cc.2.o): In function `gflags_mutex_namespace::Mutex::Unlock()':
/home/andrei/Downloads/dynamic-distance-query/bin/../lib/gflags/mutex.h:266: undefined reference to `pthread_rwlock_unlock'
lib/libgflags.a(gflags.cc.2.o): In function `gflags_mutex_namespace::Mutex::Lock()':
/home/andrei/Downloads/dynamic-distance-query/bin/../lib/gflags/mutex.h:265: undefined reference to `pthread_rwlock_wrlock'
lib/libgflags.a(gflags.cc.2.o): In function `gflags_mutex_namespace::Mutex::Unlock()':
/home/andrei/Downloads/dynamic-distance-query/bin/../lib/gflags/mutex.h:266: undefined reference to `pthread_rwlock_unlock'
lib/libgflags.a(gflags.cc.2.o): In function `gflags_mutex_namespace::Mutex::Lock()':
/home/andrei/Downloads/dynamic-distance-query/bin/../lib/gflags/mutex.h:265: undefined reference to `pthread_rwlock_wrlock'
/home/andrei/Downloads/dynamic-distance-query/bin/../lib/gflags/mutex.h:265: undefined reference to `pthread_rwlock_wrlock'
lib/libgflags.a(gflags.cc.2.o): In function `gflags_mutex_namespace::Mutex::Unlock()':
/home/andrei/Downloads/dynamic-distance-query/bin/../lib/gflags/mutex.h:266: undefined reference to `pthread_rwlock_unlock'
/home/andrei/Downloads/dynamic-distance-query/bin/../lib/gflags/mutex.h:266: undefined reference to `pthread_rwlock_unlock'
lib/libgflags.a(gflags.cc.2.o): In function `gflags_mutex_namespace::Mutex::Lock()':
/home/andrei/Downloads/dynamic-distance-query/bin/../lib/gflags/mutex.h:265: undefined reference to `pthread_rwlock_wrlock'
lib/libgflags.a(gflags.cc.2.o): In function `gflags_mutex_namespace::Mutex::Unlock()':
/home/andrei/Downloads/dynamic-distance-query/bin/../lib/gflags/mutex.h:266: undefined reference to `pthread_rwlock_unlock'
lib/libgflags.a(gflags.cc.2.o): In function `gflags_mutex_namespace::Mutex::~Mutex()':
/home/andrei/Downloads/dynamic-distance-query/bin/../lib/gflags/mutex.h:264: undefined reference to `pthread_rwlock_destroy'
lib/libgflags.a(gflags.cc.2.o): In function `gflags_mutex_namespace::Mutex::Unlock()':
/home/andrei/Downloads/dynamic-distance-query/bin/../lib/gflags/mutex.h:266: undefined reference to `pthread_rwlock_unlock'
lib/libgflags.a(gflags.cc.2.o): In function `gflags_mutex_namespace::Mutex::Lock()':
/home/andrei/Downloads/dynamic-distance-query/bin/../lib/gflags/mutex.h:265: undefined reference to `pthread_rwlock_wrlock'
lib/libgflags.a(gflags.cc.2.o): In function `gflags_mutex_namespace::Mutex::Unlock()':
/home/andrei/Downloads/dynamic-distance-query/bin/../lib/gflags/mutex.h:266: undefined reference to `pthread_rwlock_unlock'
lib/libgflags.a(gflags.cc.2.o): In function `gflags_mutex_namespace::Mutex::Mutex(gflags_mutex_namespace::Mutex::LinkerInitialized)':
/home/andrei/Downloads/dynamic-distance-query/bin/../lib/gflags/mutex.h:262: undefined reference to `pthread_rwlock_init'
collect2: error: ld returned 1 exit status
Waf: Leaving directory `/home/andrei/Downloads/dynamic-distance-query/bin'
Build failed
 -> task failed (exit status 1): 
	{task 139874094319184: cxxprogram two_layer_queue_test_main.cpp.3.o -> two_layer_queue_test}
['/usr/bin/g++', 'src/test/two_layer_queue_test_main.cpp.3.o', '-o', '/home/andrei/Downloads/dynamic-distance-query/bin/src/test/two_layer_queue_test', '-Wl,-Bstatic', '-Lsrc', '-Llib', '-Llib', '-lmy_common', '-lgtest', '-lgflags', '-Wl,-Bdynamic']
```

Adding `conf.check_cxx(lib = ['pthread'], uselib_store = 'pthread')` to `configure` in [wscript](https://github.com/flowlight0/dynamic-distance-query/blob/fdfdb70/wscript) and `'pthread'` to `use` in [src/wscript](https://github.com/flowlight0/dynamic-distance-query/blob/fdfdb70/src/wscript) fixes the issue.